### PR TITLE
画面上部の拡張機能のアイコンをクリックすると自動的に設定画面のタブが開くように変更

### DIFF
--- a/iconclicked.js
+++ b/iconclicked.js
@@ -1,0 +1,3 @@
+chrome.action.onClicked.addListener((tab) => {
+    chrome.tabs.create({"url": "options.html"});
+});

--- a/manifest.json
+++ b/manifest.json
@@ -12,5 +12,8 @@
             "js":["jquery-3.6.0.min.js","main.js"]
         }
     ],
-    "options_page":"options.html"
+    "background": {
+        "service_worker": "iconclicked.js"
+    },
+    "action": {}
 }


### PR DESCRIPTION
画面上部の、拡張機能の一覧にあるアイコンをクリックすると、自動的に設定画面のタブが開くようにして、直感的に操作しやすくなるようにしてみました。